### PR TITLE
Make AddLiquid test work with uniswap protocol fee

### DIFF
--- a/test/AddLiquid.t.sol
+++ b/test/AddLiquid.t.sol
@@ -23,17 +23,16 @@ contract AddLiquidTest is Test {
 
     function test_AddLiquidity() public {
         (uint256 reserve0, uint256 reserve1,) = IUniswapV2Pair(pool).getReserves();
-        uint256 _totalSupply = IUniswapV2Pair(pool).totalSupply();
 
         vm.prank(address(0xb0b));
         addLiquid.addLiquidity(usdc, weth, pool, reserve0, reserve1);
 
-        uint256 foo = (1000e6) - (IUniswapV2Pair(usdc).balanceOf(address(addLiquid)));
-
         uint256 puzzleBal = IUniswapV2Pair(pool).balanceOf(address(0xb0b));
 
-        uint256 bar = (foo * reserve1) / reserve0;
+        uint256 _totalSupply = IUniswapV2Pair(pool).totalSupply() - puzzleBal;
 
+        uint256 foo = (1000e6) - (IUniswapV2Pair(usdc).balanceOf(address(addLiquid)));
+        uint256 bar = (foo * reserve1) / reserve0;
         uint256 expectBal = min((foo * _totalSupply) / (reserve0), (bar * _totalSupply) / (reserve1));
 
         require(puzzleBal > 0, "No LP tokens minted");


### PR DESCRIPTION
`AddLiquidity` test started failing after Uniswap V2 enabled the protocol fee. 

```
FAIL: Incorrect LP tokens received: 7259493658357 != 7259466212966
```

If you test with an older block (before protcol fee enabled) `--fork-block-number 24106377` it works.

The old test snapshotted totalSupply before calling addLiquidity, so the expected balance didn't account for the fee LP tokens minted during the call and diverged from the actual value.

This fix reads totalSupply after the mint and subtracts puzzleBal, getting the exact post-fee, so expectBal matches puzzleBal again.